### PR TITLE
hotfix/foreground_messaging_widget

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -123,7 +123,17 @@ class _AppState extends State<App> {
     FirebaseMessaging.onMessage.listen((RemoteMessage message) {
 
       if (message.notification != null) {
-        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('출결 정보가 변경되었습니다.')));
+        showDialog(context: context, builder: (BuildContext context){
+          return AlertDialog(
+            content: Text('출결 정보가 변동되었습니다.'),
+            actions: [
+              TextButton(onPressed: () {
+                Navigator.pop(context);
+              }, child: Text('확인'))
+            ],
+          );
+        });
+        //ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('출결 정보가 변경되었습니다.')));
       }
     });
   }
@@ -178,9 +188,6 @@ class _AppState extends State<App> {
          context.go('/');
       }
   }
-
-
-
 
   @override
   Widget build(BuildContext context) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -117,25 +117,9 @@ class _AppState extends State<App> {
 
     _checkGoogleApiAvailability();
 
-    setupInteractedMessage();
+    _setupInteractedMessage();
 
-    // foreground에서 알림을 수신했을 때 변동되었음을 알리는 스낵바가 표시된다.
-    FirebaseMessaging.onMessage.listen((RemoteMessage message) {
-
-      if (message.notification != null) {
-        showDialog(context: context, builder: (BuildContext context){
-          return AlertDialog(
-            content: Text('출결 정보가 변동되었습니다.'),
-            actions: [
-              TextButton(onPressed: () {
-                Navigator.pop(context);
-              }, child: Text('확인'))
-            ],
-          );
-        });
-        //ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('출결 정보가 변경되었습니다.')));
-      }
-    });
+    _foregroundMessagingHandler();
   }
 
   /// 앱의 알림 권한을 승인하기 위한 private 메서드.
@@ -172,7 +156,7 @@ class _AppState extends State<App> {
     }
   }
 
-  Future<void> setupInteractedMessage() async {
+  Future<void> _setupInteractedMessage() async {
     RemoteMessage? initialMessage =
     await FirebaseMessaging.instance.getInitialMessage();
 
@@ -187,6 +171,24 @@ class _AppState extends State<App> {
       if (message.notification != null){
          context.go('/');
       }
+  }
+
+  _foregroundMessagingHandler() async{
+    FirebaseMessaging.onMessage.listen((RemoteMessage message) {
+
+      if (message.notification != null) {
+        showDialog(context: context, builder: (BuildContext context){
+          return AlertDialog(
+            content: Text('출결 정보가 변동되었습니다.'),
+            actions: [
+              TextButton(onPressed: () {
+                Navigator.pop(context);
+              }, child: Text('확인'))
+            ],
+          );
+        });
+      }
+    });
   }
 
   @override


### PR DESCRIPTION
## 풀 리퀘스트 점검 항목

풀 리퀘스트 시 아래 모든 항목을 적용 후 체크 표시를 해주세요.

[//]: # (대괄호 안에 공백 대신 x를 입력하면 됩니다.)

- [x] 테스트 코드를 실행하였다.
- [x] 단일 작업에서 만들어진 커밋을 모두 `Squash` 하였다.
- [x] 올바른 태그를 지정하였다.(hotfix시 hotfix태그 적용)
- [x] 올바른 작업 번호이다.
- [x] 올바른 검토자를 지정하였다.

## 해결한 이슈

[//]: # (fix #작업번호 형태의 목록으로 아래에 작성하면 됩니다.)

- fix #hotfix/foreground_messaging_widget

## 변경사항 요약

- foreground 알림이 전송될 때 알림을 표시할 위젯을 변경하였습니다.
